### PR TITLE
Create example beacon log in git rather than dropbox

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -38,6 +38,25 @@
         "doc",
         "eventOrganizing"
       ]
+    },
+    {
+      "login": "jbydeley",
+      "name": "Jared Bydeley",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/1454246?v=4",
+      "profile": "https://github.com/jbydeley",
+      "contributions": [
+        "review"
+      ]
+    },
+    {
+      "login": "benjmarshall",
+      "name": "Ben Marshall",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/6310728?v=4",
+      "profile": "http://benmarshall.co.uk",
+      "contributions": [
+        "code",
+        "review"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](docs/assets/banner.jpg)
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
 [![First-timers-only Friendly](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](http://www.firsttimersonly.com/)
 [![Twitter](https://img.shields.io/twitter/follow/theheap_.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=theheap_)
 # Project Description
@@ -70,8 +70,8 @@ Breaking Change - This is a broad term. For the purpose of this project, a break
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars2.githubusercontent.com/u/4494382?v=4" width="80px;"/><br /><sub>Bronek Szulc</sub>](https://github.com/broneks)<br />[💻](https://github.com/teesloane/Beacon/commits?author=broneks "Code") [👀](#review-broneks "Reviewed Pull Requests") | [<img src="https://avatars3.githubusercontent.com/u/563301?v=4" width="80px;"/><br /><sub>Matthew Mihok</sub>](http://mihok.today)<br />[💬](#question-mihok "Answering Questions") [👀](#review-mihok "Reviewed Pull Requests") | [<img src="https://avatars0.githubusercontent.com/u/12987958?v=4" width="80px;"/><br /><sub>Tyler</sub>](http://tylersloane.com)<br />[💻](https://github.com/teesloane/Beacon/commits?author=teesloane "Code") [🎨](#design-teesloane "Design") [📖](https://github.com/teesloane/Beacon/commits?author=teesloane "Documentation") [📋](#eventOrganizing-teesloane "Event Organizing") |
-| :---: | :---: | :---: |
+| [<img src="https://avatars2.githubusercontent.com/u/4494382?v=4" width="80px;"/><br /><sub>Bronek Szulc</sub>](https://github.com/broneks)<br />[💻](https://github.com/teesloane/Beacon/commits?author=broneks "Code") [👀](#review-broneks "Reviewed Pull Requests") | [<img src="https://avatars3.githubusercontent.com/u/563301?v=4" width="80px;"/><br /><sub>Matthew Mihok</sub>](http://mihok.today)<br />[💬](#question-mihok "Answering Questions") [👀](#review-mihok "Reviewed Pull Requests") | [<img src="https://avatars0.githubusercontent.com/u/12987958?v=4" width="80px;"/><br /><sub>Tyler</sub>](http://tylersloane.com)<br />[💻](https://github.com/teesloane/Beacon/commits?author=teesloane "Code") [🎨](#design-teesloane "Design") [📖](https://github.com/teesloane/Beacon/commits?author=teesloane "Documentation") [📋](#eventOrganizing-teesloane "Event Organizing") | [<img src="https://avatars3.githubusercontent.com/u/1454246?v=4" width="80px;"/><br /><sub>Jared Bydeley</sub>](https://github.com/jbydeley)<br />[👀](#review-jbydeley "Reviewed Pull Requests") | [<img src="https://avatars0.githubusercontent.com/u/6310728?v=4" width="80px;"/><br /><sub>Ben Marshall</sub>](http://benmarshall.co.uk)<br />[💻](https://github.com/teesloane/Beacon/commits?author=benjmarshall "Code") [👀](#review-benjmarshall "Reviewed Pull Requests") |
+| :---: | :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!

--- a/beacon_log.json
+++ b/beacon_log.json
@@ -1,0 +1,18 @@
+{
+  "logs": [
+    {
+      "ID": "lkcjvioejf23",
+      "date": "2017/01/20",
+      "author": "Joe",
+      "email": "joeshumer@joejoe.com",
+      "message": "I installed a packaged!"
+    },
+    {
+      "ID": "2o3u09fja",
+      "date": "2017/04/3",
+      "author": "Carly",
+      "email": "carly@gromponoer.com",
+      "message": "I updated the database!"
+    }
+  ]
+}

--- a/main.go
+++ b/main.go
@@ -47,7 +47,6 @@ type Log struct {
 // Vars and Constants
 // ============================
 
-// var logFilePath = path.Join(os.Getenv("HOME"), "/Dropbox/The Heap/Beacon/beacon_log.json")
 var beaconLogData BeaconLog
 
 // ============================

--- a/main.go
+++ b/main.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path"
 )
 
 // ============================
@@ -49,7 +47,7 @@ type Log struct {
 // Vars and Constants
 // ============================
 
-var logFilePath = path.Join(os.Getenv("HOME"), "/Dropbox/The Heap/Beacon/beacon_log.json")
+// var logFilePath = path.Join(os.Getenv("HOME"), "/Dropbox/The Heap/Beacon/beacon_log.json")
 var beaconLogData BeaconLog
 
 // ============================
@@ -80,7 +78,8 @@ func printLog(data BeaconLog) {
 func main() {
 
 	// read JSON file from disk
-	beaconLogFile, err := ioutil.ReadFile(path.Join(logFilePath))
+	beaconLogFile, err := ioutil.ReadFile("./beacon_log.json")
+
 	checkError(err)
 
 	// unmarshal json and store it in the pointer to beaconLogData {?}


### PR DESCRIPTION
@benjmarshall raised a good point: we are not including a beacon_log in the project directory; at the early stage of the project we were using dropbox to auto sync files. I think we should just use git for now to keep things simple, and think about how a `beacon_log.json` file might be stored / synced between projects in the future. 

