### PR TITLE
Print all command

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,12 +52,6 @@ type beaconConfig struct {
 }
 
 // ============================
-// Vars and Constants
-// ============================
-
-var beaconLogData BeaconLog
-
-// ============================
 // FUNCS
 // ============================
 
@@ -68,7 +62,9 @@ func checkError(e error) {
 }
 
 // Load the beacon log from file
-func loadLog() {
+func loadLog() BeaconLog {
+	beaconLogData := new(BeaconLog)
+
 	// read JSON file from disk
 	beaconLogFile, err := ioutil.ReadFile("./beacon_log.json")
 
@@ -79,6 +75,7 @@ func loadLog() {
 	if err := json.Unmarshal(beaconLogFile, &beaconLogData); err != nil {
 		panic(err)
 	}
+	return *beaconLogData
 }
 
 // Print the beacon log to the terminal
@@ -133,7 +130,7 @@ func main() {
 			fmt.Printf("%+v\n", log)
 			os.Exit(0)
 		case "all":
-			loadLog()
+			beaconLogData := loadLog()
 			printLog(beaconLogData)
 		default:
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func checkError(e error) {
 
 // Load the beacon log from file
 func loadLog() BeaconLog {
-	beaconLogData := new(BeaconLog)
+	var beaconLogData BeaconLog
 
 	// read JSON file from disk
 	beaconLogFile, err := ioutil.ReadFile("./beacon_log.json")
@@ -75,7 +75,7 @@ func loadLog() BeaconLog {
 	if err := json.Unmarshal(beaconLogFile, &beaconLogData); err != nil {
 		panic(err)
 	}
-	return *beaconLogData
+	return beaconLogData
 }
 
 // Print the beacon log to the terminal

--- a/main.go
+++ b/main.go
@@ -132,6 +132,7 @@ func main() {
 		case "all":
 			beaconLogData := loadLog()
 			printLog(beaconLogData)
+			os.Exit(0)
 		default:
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -67,6 +67,20 @@ func checkError(e error) {
 	}
 }
 
+// Load the beacon log from file
+func loadLog() {
+	// read JSON file from disk
+	beaconLogFile, err := ioutil.ReadFile("./beacon_log.json")
+
+	checkError(err)
+
+	// unmarshal json and store it in the pointer to beaconLogData {?}
+	// NOTE: figure out if you can use `checkError` here; don't yet understand golang's idiomatic errors handling.
+	if err := json.Unmarshal(beaconLogFile, &beaconLogData); err != nil {
+		panic(err)
+	}
+}
+
 // Print the beacon log to the terminal
 func printLog(data BeaconLog) {
 	for _, element := range data.Logs {
@@ -118,22 +132,12 @@ func main() {
 			log.Author = config.Author
 			fmt.Printf("%+v\n", log)
 			os.Exit(0)
+		case "all":
+			loadLog()
+			printLog(beaconLogData)
 		default:
 			os.Exit(1)
 		}
 	}
 
-	// read JSON file from disk
-	beaconLogFile, err := ioutil.ReadFile("./beacon_log.json")
-
-	checkError(err)
-
-	// unmarshal json and store it in the pointer to beaconLogData {?}
-	// NOTE: figure out if you can use `checkError` here; don't yet understand golang's idiomatic errors handling.
-	if err := json.Unmarshal(beaconLogFile, &beaconLogData); err != nil {
-		panic(err)
-	}
-
-	// Print the beacon log!
-	printLog(beaconLogData)
 }


### PR DESCRIPTION
Add the 'all' command feature which prints all of the beacon log messages. This has been added to the select case statement. 

Moved log reading code into it's own function so it can be called from wherever needed.

Removed global variable for the log data structure as it's not needed and bringing it in local allows for easier testing.