### PR TITLE
Refactor config out of the main package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,61 @@
+// Package config exists to load, parse and deliver a configuration struct
+// to Beacon
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/jbydeley/beacon/errors"
+)
+
+const (
+	// ErrInvalidPath is returned when the path provided is empty
+	ErrInvalidPath = errors.Error("invalid path")
+
+	// ErrAuthorRequired is returned when a config is loaded without an Author
+	ErrAuthorRequired = errors.Error("author not found in config file")
+
+	// ErrEmailRequired is returned when a config is loaded without an Email
+	ErrEmailRequired = errors.Error("email not found in config file")
+)
+
+// Config holds all configuration for beacon to work
+type Config struct {
+	Author string `json:"author"`
+	Email  string `json:"email"`
+}
+
+// LoadFile reads the file provided and returns a Config.
+func LoadFile(path string) (*Config, error) {
+	if path == "" {
+		return nil, ErrInvalidPath
+	}
+
+	body, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrap("error reading file", err)
+	}
+
+	return LoadConfig(body)
+}
+
+// LoadConfig will parse a config []byte and confirm that the config
+// has the required fields
+func LoadConfig(config []byte) (*Config, error) {
+	cfg := &Config{}
+	err := json.Unmarshal(config, &cfg)
+	if err != nil {
+		return nil, errors.Wrap("error parsing JSON", err)
+	}
+
+	if cfg.Author == "" {
+		return nil, ErrAuthorRequired
+	}
+
+	if cfg.Email == "" {
+		return nil, ErrEmailRequired
+	}
+
+	return cfg, nil
+}

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
-	"github.com/jbydeley/beacon/errors"
+	"github.com/the-heap/beacon/errors"
 )
 
 const (

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"path"
+	"testing"
+)
+
+func Test_LoadFile(t *testing.T) {
+	tt := []struct {
+		Path string
+		Err  error
+	}{
+		{
+			"valid_config.json",
+			nil,
+		}, {
+			"valid_config_extras.json",
+			nil,
+		}, {
+			"invalid_config_author.json",
+			ErrAuthorRequired,
+		}, {
+			"invalid_config_email.json",
+			ErrEmailRequired,
+		},
+	}
+
+	for _, tc := range tt {
+		path := path.Join("testdata", tc.Path)
+		_, err := LoadFile(path)
+		if err != tc.Err {
+			t.Fatalf("LoadFile(%v) returned an error (%v)", path, err)
+		}
+	}
+}
+
+func Test_LoadFile_MissingFile(t *testing.T) {
+	path := path.Join("testdata", "no_exist.json")
+	_, err := LoadFile(path)
+	if err == nil {
+		t.Fatalf("LoadFile(%v) should have returned an error but did not", path)
+	}
+}
+
+func Test_LoadFile_EmptyPath(t *testing.T) {
+	_, err := LoadFile("")
+	if err != ErrInvalidPath {
+		t.Fatalf("LoadFile(%v) should have return returned (%v)", "", ErrInvalidPath)
+	}
+}
+
+func Test_LoadConfig_InvalidJSON(t *testing.T) {
+	_, err := LoadConfig([]byte("this isn't json!"))
+	if err == nil {
+		t.Fatal("LoadConfig() return no error when passed invalid JSON")
+	}
+}

--- a/config/testdata/invalid_config_author.json
+++ b/config/testdata/invalid_config_author.json
@@ -1,0 +1,3 @@
+{
+    "email": "john.smith@example.com"
+}

--- a/config/testdata/invalid_config_email.json
+++ b/config/testdata/invalid_config_email.json
@@ -1,0 +1,3 @@
+{
+    "author": "John Smith"
+}

--- a/config/testdata/valid_config.json
+++ b/config/testdata/valid_config.json
@@ -1,0 +1,4 @@
+{
+    "author": "John Smith",
+    "email": "john.smith@example.com"
+}

--- a/config/testdata/valid_config_extras.json
+++ b/config/testdata/valid_config_extras.json
@@ -1,0 +1,5 @@
+{
+    "author": "John Smith",
+    "email": "john.smith@example.com",
+    "something": "this should be ignored"
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,7 +2,8 @@ package errors
 
 import "fmt"
 
-// Error allows us to create constant errors
+// Error allows us to create constant errors. See:
+// https://dave.cheney.net/2016/04/07/constant-errors
 type Error string
 
 func (e Error) Error() string {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// Error allows us to create constant errors
+type Error string
+
+func (e Error) Error() string {
+	return string(e)
+}
+
+// Wrap returns an Error with a prepended msg
+func Wrap(msg string, err error) Error {
+	return Error(fmt.Sprintf("%v: %v", msg, err))
+}

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/jbydeley/beacon/config"
+	"github.com/the-heap/beacon/config"
 )
 
 // ============================

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/jbydeley/beacon/config"
 )
 
 // ============================
@@ -44,11 +46,6 @@ type Log struct {
 	Email   string
 	Author  string
 	Message string
-}
-
-type beaconConfig struct {
-	Author string `json:"author"`
-	Email  string `json:"email"`
 }
 
 // ============================
@@ -90,16 +87,6 @@ func printLog(data BeaconLog) {
 	}
 }
 
-// loadConfig loads the .beaconrc file into the beaconConfig
-func loadConfig(config *beaconConfig) error {
-	configFile, err := ioutil.ReadFile("./.beaconrc")
-	if err != nil {
-		return err
-	}
-
-	return json.Unmarshal(configFile, &config)
-}
-
 func prompt(question string) string {
 	reader := bufio.NewReader(os.Stdin)
 	fmt.Print(question)
@@ -112,9 +99,8 @@ func prompt(question string) string {
 // MAIN!
 // ============================
 func main() {
-	var config beaconConfig
-
-	if err := loadConfig(&config); err != nil {
+	cfg, err := config.LoadFile("./.beaconrc")
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -126,7 +112,8 @@ func main() {
 		case "add":
 			log := Log{}
 			log.Message = prompt("Enter message: ")
-			log.Author = config.Author
+			log.Email = cfg.Email
+			log.Author = cfg.Author
 			fmt.Printf("%+v\n", log)
 			os.Exit(0)
 		case "all":


### PR DESCRIPTION
Fix for #18 

- Rename beaconConfig to Config
- Create config package
  - Add tests and test data
- Create errors package
  - Allow easy error constants