### PR TITLE
Create beaconlog package

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,28 +23,13 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/the-heap/beacon/messagelog"
 )
 
 // ============================
 // Types
 // ============================
-
-// BeaconLog represents the entire blob of json from the beacon file
-type BeaconLog struct {
-	Logs []Log
-}
-
-// Log is a single entry in the BeaconLog;
-//
-// _Example_: a user submits a breaking change to the database,
-// in which they would fill out all the info in this struct.
-type Log struct {
-	ID      string
-	Date    string
-	Email   string
-	Author  string
-	Message string
-}
 
 type beaconConfig struct {
 	Author string `json:"author"`
@@ -58,35 +43,6 @@ type beaconConfig struct {
 func checkError(e error) {
 	if e != nil {
 		panic(e)
-	}
-}
-
-// Load the beacon log from file
-func loadLog() BeaconLog {
-	var beaconLogData BeaconLog
-
-	// read JSON file from disk
-	beaconLogFile, err := ioutil.ReadFile("./beacon_log.json")
-
-	checkError(err)
-
-	// unmarshal json and store it in the pointer to beaconLogData {?}
-	// NOTE: figure out if you can use `checkError` here; don't yet understand golang's idiomatic errors handling.
-	if err := json.Unmarshal(beaconLogFile, &beaconLogData); err != nil {
-		panic(err)
-	}
-	return beaconLogData
-}
-
-// Print the beacon log to the terminal
-func printLog(data BeaconLog) {
-	for _, element := range data.Logs {
-		fmt.Println("")
-		fmt.Println("==========================================")
-		fmt.Println("Date: ", element.Date)
-		fmt.Println("Author: ", element.Author+" ("+element.Email+")") // I bet there's a nicer way to do this.
-		fmt.Println("Message: ", element.Message)
-		fmt.Println("==========================================")
 	}
 }
 
@@ -124,14 +80,14 @@ func main() {
 	if len(os.Args) == 2 {
 		switch os.Args[1] {
 		case "add":
-			log := Log{}
+			log := messagelog.Log{}
 			log.Message = prompt("Enter message: ")
 			log.Author = config.Author
 			fmt.Printf("%+v\n", log)
 			os.Exit(0)
 		case "all":
-			beaconLogData := loadLog()
-			printLog(beaconLogData)
+			beaconLogData := messagelog.LoadLog("./beacon_log.json")
+			beaconLogData.PrintLog()
 			os.Exit(0)
 		default:
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 			os.Exit(0)
 		case "all":
 			beaconLogData := messagelog.LoadLog("./beacon_log.json")
-			beaconLogData.PrintLog()
+			fmt.Println(beaconLogData)
 			os.Exit(0)
 		default:
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -18,14 +18,12 @@ package main
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
-	"github.com/the-heap/beacon/messagelog"
 	"github.com/the-heap/beacon/config"
+	"github.com/the-heap/beacon/messagelog"
 )
 
 // ============================

--- a/messagelog/messagelog.go
+++ b/messagelog/messagelog.go
@@ -1,0 +1,58 @@
+// Package messagelog provides the data type for holding the beacon log data
+// and methods for loading and storing to/from the log file
+package messagelog
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+)
+
+// BeaconLog represents the entire blob of json from the beacon file
+type BeaconLog struct {
+	Logs []Log
+}
+
+// Log is a single entry in the BeaconLog;
+//
+// _Example_: a user submits a breaking change to the database,
+// in which they would fill out all the info in this struct.
+type Log struct {
+	ID      string
+	Date    string
+	Email   string
+	Author  string
+	Message string
+}
+
+// LoadLog loads the beacon log from the specified file
+func LoadLog(logFile string) BeaconLog {
+	var beaconLogData BeaconLog
+
+	// read JSON file from disk
+	beaconLogFile, err := ioutil.ReadFile(logFile)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// unmarshal json and store it in the pointer to beaconLogData {?}
+	// NOTE: figure out if you can use `checkError` here; don't yet understand golang's idiomatic errors handling.
+	if err := json.Unmarshal(beaconLogFile, &beaconLogData); err != nil {
+		log.Fatal(err)
+	}
+	return beaconLogData
+}
+
+// PrintLog prints the beacon log to the terminal
+func (data *BeaconLog) PrintLog() {
+	for _, element := range data.Logs {
+		fmt.Println("")
+		fmt.Println("==========================================")
+		fmt.Println("Date: ", element.Date)
+		fmt.Println("Author: ", element.Author+" ("+element.Email+")") // I bet there's a nicer way to do this.
+		fmt.Println("Message: ", element.Message)
+		fmt.Println("==========================================")
+	}
+}

--- a/messagelog/messagelog.go
+++ b/messagelog/messagelog.go
@@ -45,14 +45,15 @@ func LoadLog(logFile string) BeaconLog {
 	return beaconLogData
 }
 
-// PrintLog prints the beacon log to the terminal
-func (data *BeaconLog) PrintLog() {
+// String implements the stringer interface for the BeaconLog struct
+func (data BeaconLog) String() string {
+	var stringOutput string
 	for _, element := range data.Logs {
-		fmt.Println("")
-		fmt.Println("==========================================")
-		fmt.Println("Date: ", element.Date)
-		fmt.Println("Author: ", element.Author+" ("+element.Email+")") // I bet there's a nicer way to do this.
-		fmt.Println("Message: ", element.Message)
-		fmt.Println("==========================================")
+		stringOutput = stringOutput + fmt.Sprintf("\n==========================================\n")
+		stringOutput = stringOutput + fmt.Sprintf("Date: %s\n", element.Date)
+		stringOutput = stringOutput + fmt.Sprintf("Author: %s (%s)\n", element.Author, element.Email)
+		stringOutput = stringOutput + fmt.Sprintf("Message: %s\n", element.Message)
+		stringOutput = stringOutput + fmt.Sprintf("==========================================\n")
 	}
+	return stringOutput
 }

--- a/messagelog/messagelog_test.go
+++ b/messagelog/messagelog_test.go
@@ -1,0 +1,41 @@
+package messagelog
+
+import "testing"
+
+func TestString(t *testing.T) {
+	type test struct {
+		beaconLogData BeaconLog
+		expected      string
+	}
+
+	testArray := []test{
+		{
+			beaconLogData: BeaconLog{
+				Logs: []Log{
+					Log{
+						ID:      "1234abcd",
+						Date:    "2017/07/19",
+						Email:   "j@jh.com",
+						Author:  "John Henry",
+						Message: "I broke lots of things!",
+					},
+				},
+			},
+			expected: `
+==========================================
+Date: 2017/07/19
+Author: John Henry (j@jh.com)
+Message: I broke lots of things!
+==========================================
+`,
+		},
+	}
+
+	for _, test := range testArray {
+		got := test.beaconLogData.String()
+		if got != test.expected {
+			t.Errorf("Got doesn't equal expected result:\nGot:%v\nWant:%v\n", got, test.expected)
+		}
+	}
+
+}


### PR DESCRIPTION
beaconLog type and all associated functions have been moved to a seperate package - mesagelog. 

main.go has been updated to use the new package.

PrintLog command changed in favour of implementing the Stringer interface.

Test file added to the messagelog package and basic test written.