### PR TITLE
Move prompt to a helpers package

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -1,0 +1,18 @@
+// Package helpers provides general functions that don't
+// exactly belond to a single other package.
+package helpers
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// Prompt gets text input from the user and returns it as a string.
+func Prompt(question string) string {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print(question)
+	message, _ := reader.ReadString('\n')
+
+	return message
+}

--- a/main.go
+++ b/main.go
@@ -17,8 +17,6 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
 	"log"
 	"os"
 
@@ -26,21 +24,6 @@ import (
 	"github.com/the-heap/beacon/messages"
 )
 
-// ============================
-// FUNCS
-// ============================
-
-func prompt(question string) string {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Print(question)
-	message, _ := reader.ReadString('\n')
-
-	return message
-}
-
-// ============================
-// MAIN!
-// ============================
 func main() {
 	cfg, err := config.Load("./.beaconrc")
 	if err != nil {


### PR DESCRIPTION
This will perhaps not get used right away but I suspect we might use it
later; and in the meantime, clean up our `main.go`